### PR TITLE
fix调用popToViewControlle: animated: 后，左滑返回时底部截图显示错误

### DIFF
--- a/KKNavigationController/KKNavigationController.m
+++ b/KKNavigationController/KKNavigationController.m
@@ -85,6 +85,14 @@
     return [super popViewControllerAnimated:animated];
 }
 
+- (NSArray *)popToViewController:(UIViewController *)viewController animated:(BOOL)animated{
+    NSInteger index = [self.viewControllers indexOfObject:viewController];
+    if (index != NSNotFound) {
+        [self.screenShotsList removeObjectsInRange:NSMakeRange(index + 1, self.viewControllers.count - index - 1)];
+    }
+    return [super popToViewController:viewController animated:animated];
+}
+
 #pragma mark - Utility Methods -
 
 - (UIImage *)capture


### PR DESCRIPTION
调用popToViewControlle: animated:时未能remove 截屏
//remove poped captures when called  popToViewControlle: animated:
